### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/keep_alive.yml
+++ b/.github/workflows/keep_alive.yml
@@ -1,5 +1,8 @@
 name: Keep Repository Alive
 
+permissions:
+  contents: write
+
 on:
   schedule:
     - cron: '0 0 * * *'


### PR DESCRIPTION
Potential fix for [https://github.com/TheLumiDevs/fP-extension-build/security/code-scanning/1](https://github.com/TheLumiDevs/fP-extension-build/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly limit the permissions of the `GITHUB_TOKEN` to the minimum required for the workflow to function. Since the workflow involves checking out the repository and creating an empty commit, the `contents: write` permission is necessary. Other permissions will be omitted to minimize the risk of misuse.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
