### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/license-update.yml
+++ b/.github/workflows/license-update.yml
@@ -1,4 +1,6 @@
 name: Notify on LICENSE update
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/TheLumiDevs/fP-extension-build/security/code-scanning/8](https://github.com/TheLumiDevs/fP-extension-build/security/code-scanning/8)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code and sends a notification (and does not push, create issues, or perform any write operations), the minimal permission required is `contents: read`. This block can be added at the top level of the workflow (applies to all jobs) or at the job level (applies only to the specific job). The best practice is to add it at the top level unless a job needs different permissions. Edit `.github/workflows/license-update.yml` to add the following block after the `name:` line and before the `on:` block:

```yaml
permissions:
  contents: read
```

No additional methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
